### PR TITLE
Set GoodJob dashboard up for super_admins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'sassc', '~> 2.0', '>= 2.0.1'
 gem 'stripe', '~> 1.58' # January 19, 2017 version of the Stripe API https://stripe.com/docs/api
 gem 'webpacker', '~> 5.2.1'
 gem 'react-rails'
+gem 'good_job'
 
 gem 'httparty', '~> 0.17.0' # https://github.com/jnunemaker/httparty
 gem 'rack-attack', '~> 5.2' # for blocking ip addressses

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,13 @@ GEM
       rack
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    good_job (1.7.1)
+      activejob (>= 5.2.0)
+      activerecord (>= 5.2.0)
+      concurrent-ruby (>= 1.0.2)
+      railties (>= 5.2.0)
+      thor (>= 0.14.1)
+      zeitwerk (>= 2.0)
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashdiff (1.0.1)
@@ -405,6 +412,7 @@ DEPENDENCIES
   factory_bot_rails (~> 5.0, >= 5.0.2)
   fast_blank
   font_assets (~> 0.1.14)
+  good_job
   hamster (~> 3.0)
   heroku-deflater (~> 0.6.3)
   houdini_full_contact!

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -1054,6 +1054,38 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
+** actionmailer; version 6.1.3 -- 
+** actionpack; version 6.1.3 -- 
+** actionview; version 6.1.3 -- 
+** activemodel; version 6.1.3 -- 
+** railties; version 6.1.3 -- 
+Copyright (c) 2006-2013 Paul Battley, Michael Neumann, Tim Fletcher.
+
+Copyright (c) 2004-2020 David Heinemeier Hansson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+------
+
 ** rb-fsevent; version 0.10.4 -- 
 Copyright (c) 2013, Facebook, Inc.
 Copyright (c) 2011 Konstantin Haase
@@ -1710,6 +1742,33 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
+** actioncable; version 6.1.3 -- 
+Copyright (c) 2010-2015 James Coglan
+
+Copyright (c) 2015-2020 Basecamp, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+------
+
 ** money; version 6.13.8 -- 
 Copyright (c) 2008 Phusion
 Copyright (c) 2005 Tobias Lutke
@@ -2035,6 +2094,33 @@ THE SOFTWARE.
 
 ------
 
+** good_job; version 1.7.1 -- 
+Copyright (c) 2019 Gion Kunz Free
+
+Copyright 2020 Ben Sheldon
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+------
+
 ** webpacker; version 5.2.1 -- 
 Copyright (c) 2016-2019 David Heinemeier Hansson, Basecamp
 
@@ -2239,6 +2325,60 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
+** actionmailbox; version 6.1.3 -- 
+
+MIT License
+
+Copyright (c) 2018-2020 Basecamp, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+------
+
+** actiontext; version 6.1.3 -- 
+
+MIT License
+
+Copyright (c) 2020 Basecamp, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+------
+
 ** netrc; version 0.11.0 -- 
 Copyright (c) 2011-2014 CONTRIBUTORS.md (https://github.com/geemus/netrc/blob/master/CONTRIBUTORS.md)
 
@@ -2424,6 +2564,33 @@ Copyright (c) 2008-2012 Sven Fuchs and contributors (see https://github.com/sven
 (c) Yaroslav Markin, Julian julik Tarkhanov and Co https://github.com/yaroslav/russian/blob/master/lib/russian/transliteration.rb
 
 Copyright (c) 2008-2012 Sven Fuchs and contributors (see https://github.com/svenfuchs/rails-i18n/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+------
+
+** activejob; version 6.1.3 -- 
+
+Copyright (c) 2014-2020 David Heinemeier Hansson
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -2640,6 +2807,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
+** activerecord; version 6.1.3 -- 
+copyright (c) 2007-2016 Nick Kallen, Bryan Helmkamp, Emilio Tagua, Aaron Patterson
 ** coderay; version 1.1.3 -- 
 Copyright (c) 2005-2012 Kornelius Kalnbach <murphy@rubychan.de>
 ** crack; version 0.4.5 -- 
@@ -2686,6 +2855,7 @@ Copyright (c) Django Software Foundation and individual contributors.
 Copyright (c) 2007-2019 Leah Neukirchen <http://leahneukirchen.org/infopage.html>
 ** rack-attack; version 5.4.2 -- 
 Copyright Kickstarter, PBC.
+** rails; version 6.1.3 -- 
 ** rails-dom-testing; version 2.0.3 -- 
 Copyright (c) 2013-2015 Kasper Timm Hansen
 ** rails-html-sanitizer; version 1.3.0 -- 
@@ -2702,6 +2872,32 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------
+
+** activesupport; version 6.1.3 -- 
+
+Copyright (c) 2005-2020 David Heinemeier Hansson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ------
 
@@ -3057,6 +3253,32 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+------
+
+** activestorage; version 6.1.3 -- 
+
+Copyright (c) 2017-2020 David Heinemeier Hansson, Basecamp
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ------

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,15 @@ class User < ApplicationRecord
     self
   end
 
+  #
+  # Is this user a super_admin?
+  #
+  # @return [boolean] True if the user is, false otherwise
+  #
+  def super_admin?
+    roles.super_admins.any?
+  end
+
   # This creates the user in the normal way, but also sends the devise email confirmation email, which we don't want to send to np admins or anyone else
   def self.register_donor!(params)
     u = User.create!(params)

--- a/config/application.rb
+++ b/config/application.rb
@@ -108,6 +108,8 @@ module Commitchange
 
     config.active_storage.draw_routes = false
 
+    config.active_job.queue_adapter = :good_job
+
     # this works around a bug where the the webpacker proxy
     # only waits 60 seconds for a compilation to happen. That's not 
     # fast enough on startup and Webpacker doesn't allow us to override.

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require_relative 'boot'
 
 require "rails"
 # Pick the frameworks you want:
+require "good_job/engine"
 require "active_model/railtie"
 require "active_job/railtie"
 require "active_record/railtie"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -211,6 +211,11 @@ Rails.application.routes.draw do
   match '/admin/export_supporters_with_rds' => 'super_admins#export_supporters_with_rds', via: %i[get post]
   match '/admin/resend_user_confirmation' => 'super_admins#resend_user_confirmation', via: %i[get post]
 
+  # GoodJob dashboard
+  authenticate :user, ->(user) { user.super_admin? } do
+    mount GoodJob::Engine => 'good_job'
+  end
+
   # Events
   match '/events' => 'events#index', via: [:get]
   match '/events/:event_slug' => 'events#show', via: %i[get post]

--- a/db/migrate/20210217225909_create_good_jobs.rb
+++ b/db/migrate/20210217225909_create_good_jobs.rb
@@ -1,0 +1,20 @@
+class CreateGoodJobs < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension 'pgcrypto'
+
+    create_table :good_jobs, id: :uuid do |t|
+      t.text :queue_name
+      t.integer :priority
+      t.jsonb :serialized_params
+      t.timestamp :scheduled_at
+      t.timestamp :performed_at
+      t.timestamp :finished_at
+      t.text :error
+
+      t.timestamps
+    end
+
+    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)"
+    add_index :good_jobs, [:queue_name, :scheduled_at], where: "(finished_at IS NULL)"
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe User, type: :model do
 			sa.roles.create(name: 'nonprofit_associate')
 			sa
 		}
+
+		let(:no_roles) {
+			sa = create(:user)
+			sa
+		}
 		
 		it 'returns true for super admin' do
 			expect(super_admin).to be_super_admin
@@ -26,6 +31,10 @@ RSpec.describe User, type: :model do
 
 		it 'returns false for not super admin' do
 			expect(not_super_admin).to_not be_super_admin
+		end
+
+		it 'returns false when has no roles' do
+			expect(no_roles).to_not be_super_admin
 		end
 	end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'super_admin?' do 
+		let(:super_admin) { 
+			sa = create(:user)
+
+			sa.roles.create(name: 'super_admin')
+			sa
+		}
+
+		let(:not_super_admin) {
+			sa = create(:user)
+			sa.roles.create(name: 'nonprofit_admin')
+			sa.roles.create(name: 'nonprofit_associate')
+			sa
+		}
+		
+		it 'returns true for super admin' do
+			expect(super_admin).to be_super_admin
+		end
+
+		it 'returns false for not super admin' do
+			expect(not_super_admin).to_not be_super_admin
+		end
+	end
+end

--- a/spec/requests/good_job_protection_spec.rb
+++ b/spec/requests/good_job_protection_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+require 'rails_helper'
+
+describe 'GoodJob protection' do
+	let(:user) { create(:user) }
+
+	describe 'when it is a super_admin' do
+		it 'shows the good job dashboard' do
+			user.roles.create(name: 'super_admin')
+			sign_in user
+			get('/good_job')
+			expect(response).to have_http_status(:success)
+		end
+	end
+
+	describe 'when not logged in' do
+		it 'is redirected to log in page' do
+			get('/good_job')
+			expect(response).to have_http_status(:redirect)
+		end
+	end
+
+	describe 'when logged in but is not super_admin' do
+		it 'raises RoutingError' do
+			sign_in user
+			expect{ get('/good_job') }.to raise_error(ActionController::RoutingError)
+		end
+	end
+end


### PR DESCRIPTION
The GoodJob dashboard was configured using the documentation from [this page](https://github.com/bensheldon/good_job#dashboard).

![Screenshot from 2021-02-21 10-25-52](https://user-images.githubusercontent.com/15739610/108626620-d4f45780-742f-11eb-95bc-39733abbb8bc.png)

The succeeded jobs are not currently showing up on the dashboard, but I suspect this is related to GoodJob configuration itself, not to the dashboard configuration.